### PR TITLE
SPIKE(snowflake): begin of some whitespace preservation

### DIFF
--- a/src/expr.js
+++ b/src/expr.js
@@ -56,7 +56,7 @@ function varToSQL(expr) {
 
 exprToSQLConvertFn.var = varToSQL
 
-function exprToSQL(exprOrigin) {
+function exprToSQL(exprOrigin, renderOptions) {
   if (!exprOrigin) return
   const expr = exprOrigin
   if (exprOrigin.ast) {
@@ -66,7 +66,8 @@ function exprToSQL(exprOrigin) {
       expr[key] = ast[key]
     }
   }
-  return exprToSQLConvertFn[expr.type] ? exprToSQLConvertFn[expr.type](expr) : literalToSQL(expr)
+
+  return exprToSQLConvertFn[expr.type] ? exprToSQLConvertFn[expr.type](expr, renderOptions) : literalToSQL(expr)
 }
 
 function unaryToSQL(unarExpr) {

--- a/src/limit.js
+++ b/src/limit.js
@@ -1,14 +1,21 @@
 import { connector, toUpper, hasVal } from './util'
 import { exprToSQL } from './expr'
+import { whitespace } from './whitespace'
 
 function composePrefixValSuffix(stmt) {
   if (!stmt) return []
   return [toUpper(stmt.prefix), exprToSQL(stmt.value), toUpper(stmt.suffix)]
 }
 
-function fetchOffsetToSQL(stmt) {
+function fetchOffsetToSQL(stmt, renderOptions) {
   const { fetch, offset } = stmt
-  const result = [...composePrefixValSuffix(offset), ...composePrefixValSuffix(fetch)]
+  const wspc = (renderOptions && renderOptions.preserveWhitespace) ? (stmt.wspc ?? {}) : {}
+
+  const result = [
+    ...composePrefixValSuffix(offset),
+    ...composePrefixValSuffix(fetch),
+    whitespace(wspc.after, ''),
+  ]
   return result.filter(hasVal).join(' ')
 }
 
@@ -18,10 +25,12 @@ function limitOffsetToSQL(limit) {
   return connector('LIMIT', value.map(exprToSQL).join(`${seperator === 'offset' ? ' ' : ''}${toUpper(seperator)} `))
 }
 
-function limitToSQL(limit) {
+function limitToSQL(limit, renderOptions) {
   if (!limit) return ''
-  if (limit.fetch) return fetchOffsetToSQL(limit)
-  return limitOffsetToSQL(limit)
+  if (limit.fetch) {
+    return fetchOffsetToSQL(limit, renderOptions)
+  }
+  return limitOffsetToSQL(limit, renderOptions)
 }
 
 export {

--- a/src/parser.js
+++ b/src/parser.js
@@ -11,12 +11,12 @@ class Parser {
 
   sqlify(ast, opt = DEFAULT_OPT) {
     setParserOpt(opt)
-    return astToSQL(ast, opt)
+    return astToSQL(ast, opt.renderOptions ?? {})
   }
 
   exprToSQL(expr, opt = DEFAULT_OPT) {
     setParserOpt(opt)
-    return exprToSQL(expr)
+    return exprToSQL(expr, opt.renderOptions ?? {})
   }
 
   parse(sql, opt = DEFAULT_OPT) {

--- a/src/sql.js
+++ b/src/sql.js
@@ -7,23 +7,23 @@ function checkSupported(expr) {
   if (!supportedTypes.includes(ast.type)) throw new Error(`${ast.type} statements not supported at the moment`)
 }
 
-function toSQL(ast) {
+function toSQL(ast, renderOptions) {
   if (Array.isArray(ast)) {
     ast.forEach(checkSupported)
-    return multipleToSQL(ast)
+    return multipleToSQL(ast, renderOptions)
   }
   checkSupported(ast)
-  return unionToSQL(ast)
+  return unionToSQL(ast, renderOptions)
 }
 
-function goToSQL(stmt) {
+function goToSQL(stmt, renderOptions) {
   if (!stmt || stmt.length === 0) return ''
   const res = [toSQL(stmt.ast)]
-  if (stmt.go_next) res.push(stmt.go.toUpperCase(), goToSQL(stmt.go_next))
+  if (stmt.go_next) res.push(stmt.go.toUpperCase(), goToSQL(stmt.go_next, renderOptions))
   return res.filter(sqlItem => sqlItem).join(' ')
 }
 
-export default function astToSQL(ast) {
-  const sql = ast.go === 'go' ? goToSQL(ast) : toSQL(ast)
+export default function astToSQL(ast, renderOptions) {
+  const sql = ast.go === 'go' ? goToSQL(ast, renderOptions) : toSQL(ast, renderOptions)
   return sql
 }

--- a/src/util.js
+++ b/src/util.js
@@ -13,9 +13,10 @@ import { columnToSQL, columnRefToSQL, columnOrderToSQL } from './column'
 // }
 
 const DEFAULT_OPT = {
-  database     : PARSER_NAME || 'mysql',
-  type         : 'table',
-  parseOptions : {},
+  database      : PARSER_NAME || 'mysql',
+  type          : 'table',
+  parseOptions  : {},
+  renderOptions : {},
 }
 
 let parserOpt = DEFAULT_OPT
@@ -115,13 +116,14 @@ function setParserOpt(opt) {
   parserOpt = opt
 }
 
-function topToSQL(opt) {
+function topToSQL(opt, renderOptions) {
   if (!opt) return
   const { value, percent, parentheses } = opt
-  const val = parentheses ? `(${value})` : value
-  const prefix = `TOP ${val}`
+  const wspc = (renderOptions && renderOptions.preserveWhitespace) ? (opt.wspc ?? {}) : {}
+  const val = parentheses ? `(${value}${wspc.afterValue ?? ''})` : value
+  const prefix = `TOP${wspc.afterTop ?? ' '}${val}`
   if (!percent) return prefix
-  return `${prefix} ${percent.toUpperCase()}`
+  return `${prefix}${wspc.beforePercent ?? ' '}${percent.toUpperCase()}${wspc.afterPercent ?? ''}`
 }
 
 function columnIdentifierToSql(ident) {
@@ -186,6 +188,13 @@ function toUpper(val) {
 
 function hasVal(val) {
   return val
+}
+function filterResult(result) {
+  const res = result.filter(hasVal)
+  while ((res.length > 0) && !res[res.length - 1].trim()) {
+    res.pop()
+  }
+  return res
 }
 
 function literalToSQL(literal) {
@@ -362,5 +371,5 @@ export {
   connector, commonTypeValue,commentToSQL, createBinaryExpr,
   createValueExpr, dataTypeToSQL, DEFAULT_OPT, escape, literalToSQL, columnIdentifierToSql,
   getParserOpt, identifierToSql, onPartitionsToSQL, replaceParams, returningToSQL,
-  hasVal, setParserOpt, toUpper, topToSQL, triggerEventToSQL,
+  hasVal, filterResult, setParserOpt, toUpper, topToSQL, triggerEventToSQL,
 }

--- a/src/whitespace.js
+++ b/src/whitespace.js
@@ -1,0 +1,33 @@
+function whitespace(wspc, replacement) {
+  if (!wspc || !Array.isArray(wspc) || wspc.length === 0) {
+    return replacement
+  }
+
+  const res = []
+  for (const elt of wspc) {
+    if (typeof elt === 'string') {
+      res.push(elt)
+    } else if (Array.isArray(elt)) {
+      for (const subElt of elt) {
+        if (typeof subElt === 'string') {
+          res.push(subElt)
+        } else if (Array.isArray(subElt)) {
+          for (const sse of subElt) {
+            // eslint-disable-next-line max-depth
+            if (typeof sse === 'string') {
+              res.push(sse)
+              // eslint-disable-next-line no-magic-numbers
+            } else if (Array.isArray(sse) && sse.length === 3 && (!sse[0]) && (!sse[1])) {
+              res.push(sse[2])
+            }
+          }
+        }
+      }
+    }
+  }
+  return res.join('')
+}
+
+export {
+  whitespace,
+}

--- a/src/with.js
+++ b/src/with.js
@@ -1,20 +1,32 @@
 import { columnRefToSQL } from './column'
 import { exprToSQL } from './expr'
-import { identifierToSql, literalToSQL } from './util'
+import { filterResult, identifierToSql, literalToSQL } from './util'
+import { whitespace } from './whitespace'
 
 /**
- * @param {Array<Object>} withExpr
+ *
+ * note on the space after WITH: could preserve whitespace here too
  */
-function withToSQL(withExpr) {
-  if (!withExpr || withExpr.length === 0) return
-  const isRecursive = withExpr[0].recursive ? 'RECURSIVE ' : ''
-  const withExprStr = withExpr.map(cte => {
+function withToSQL(withExpr, renderOptions) {
+  if (!withExpr || !withExpr.content || withExpr.content.length === 0) return
+  const result = []
+  const wspc = (renderOptions && renderOptions.preserveWhitespace) ? (withExpr.wspc ?? {}) : {}
+  result.push(whitespace(wspc.before, ''))
+  result.push('WITH ')
+  result.push(withExpr.content[0].recursive ? 'RECURSIVE ' : '')
+
+  const withExprElements = withExpr.content.map(cte => {
     const { name, stmt, columns } = cte
     const column = Array.isArray(columns) ? `(${columns.map(columnRefToSQL).join(', ')})` : ''
     return `${name.type === 'default' ? identifierToSql(name.value) : literalToSQL(name)}${column} AS (${exprToSQL(stmt)})`
-  }).join(', ')
-
-  return `WITH ${isRecursive}${withExprStr}`
+  })
+  withExprElements.forEach((elt, idx) => {
+    if (idx > 0) {
+      result.push(', ')
+    }
+    result.push(elt)
+  })
+  return filterResult(result).join('') + whitespace(wspc.after, ' ')
 }
 
 export {

--- a/test/snowflake.spec.js
+++ b/test/snowflake.spec.js
@@ -4,7 +4,7 @@ const Parser = require('../src/parser').default
 describe('snowflake', () => {
   const parser = new Parser();
   const opt = {
-    database: 'snowflake'
+    database: 'snowflake',
   }
 
   function getParsedSql(sql, opt) {
@@ -140,5 +140,20 @@ describe('snowflake', () => {
     it(`should support ${title}`, () => {
       expect(getParsedSql(sql[0], opt)).to.equal(sql[1])
     })
+  })
+
+  it('should support some whitespace & comment preservation', () => {
+    const sql =  `/* test */ SELECT /* test */ listing_id AS with_whitespace_listing_id,
+        listing_name,
+        room_type,
+        host_id,
+        REPLACE(price_str, '$') :: NUMBER(10, 2) AS price,
+        created_at,
+        updated_at
+        FROM  -- this will require a larger intervention in 'from_clause'
+
+        src_listings`;
+    expect(getParsedSql(sql, { ...opt, renderOptions: { preserveWhitespace: true }}))
+      .to.equal('SELECT /* test */ "listing_id" AS "with_whitespace_listing_id", "listing_name", "room_type", "host_id", REPLACE("price_str", \'$\')::NUMBER(10, 2) AS "price", "created_at", "updated_at" FROM "src_listings"')
   })
 })


### PR DESCRIPTION
a time-boxed discovery experiment of what it would take to support preservation of whitespace.

I've concentrated on snowflake, and appear to have broken about everything else...

- *every* use of `__` and `___` would need to be bound to a return variable and consumed at the right time during the conversion of AST back to SQL.
- when whitespace preservation isn't requested, every use of `__` and `___` should instead be returned to `''` or `' '` as currently... but in a "smart" way
- expressions such as `from_clause` that currently return a list would become inconvenient; as we would need to:
   1. make them return a struct with the contents and the labelled whitespace containers 
   2. wherever these clauses are used, we should unpack the struct back into the list on one hand, the whitespace containers on the other (in order to preserve the existing API)
   3. all of this has to be done in an identical manner in all 12 SQL parsers simultaneously

it's not unfeasible, but it is, unfortunately, a far more complex exercise than what I can commit at this moment.

I hope this is helpful!